### PR TITLE
Change argument signature to be less verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ Useful if you have an untrustworthy data source. It will probably save you a bit
 ```javascript
 var getOrElse = require("get-or-else");
 
-window.a = {x:4};
-getOrElse({ get: [window,'a.b.c'], else: {} });
-// {} - does not exist, so `else` is used
-getOrElse({ get: [window,'a'], else: {} })
-// {x:4} - does exist, so expected value is returned
+window.a = { x: 4 };
+
+getOrElse([ window, 'a.b.c' ], {});
+// returns {} as window.a.b.c does not exist, so `else` is used
+
+getOrElse([ window, 'a' ], {});
+// returns { x: 4 } as window.a does exist, so expected value is returned
 ```
 
 ### Example ES6 Redux
@@ -31,7 +33,7 @@ export const name = (state = {}, action = {}) => {
     case 'SET_FIRSTNAME':
       return {
         ...state,
-        firstName: getOrElse({ get: [action,'payload.name.first'], else: undefined })
+        firstName: getOrElse([ action, 'payload.name.first' ], undefined)
       };
 
     default:
@@ -55,18 +57,15 @@ const nameObj = {
   }
 };
 
-const salutation = getOrElse({  get: [nameObj,'salutation'], else: false });
+const salutation = getOrElse([ nameObj, 'salutation' ], false);
 
 const NameComponent = () => {
   return (
     <h1>
       We have been expecting you
-
       {salutation && <span> {salutation}</span>}
-
-      <span> {getOrElse({ get: [nameObj,'name.first'], else: '' })}</span>
-
-      <span> {getOrElse({ get: [nameObj,'name.last'], else: '' })}</span>
+      <span> {getOrElse([ nameObj, 'name.first' ], '')}</span>
+      <span> {getOrElse([ nameObj,'name.last' ], '')}</span>
     </h1>
   );
 };

--- a/index.js
+++ b/index.js
@@ -14,16 +14,16 @@
  * getOrElse({ get: [window,'a'], else: {} }) // {x:4} - does exist, so expected value is returned
  */
 
-var getOrElse = function( getOrElseObj ) {
-  if (!getOrElseObj.get[0]) return getOrElseObj.else;
-  var contextObj = getOrElseObj.get[0];
-  var namespace = getOrElseObj.get[1].split('.');
+var getOrElse = function( get, backup ) {
+  if (!get[0]) return backup;
+  var contextObj = get[0];
+  var namespace = get[1].split('.');
   var value = contextObj; // reassigns to obj[key] on each array.every iteration
   return (
     namespace.every( function( key ) {
       return (value = value[key]) != undefined;
     })
-	) ? value : getOrElseObj.else;
+	) ? value : backup;
 };
 
 module.exports = getOrElse;

--- a/index__test__.js
+++ b/index__test__.js
@@ -15,28 +15,28 @@ var testObj = {
 describe('getOrElse', function(){
 
   it('should return the default `else` param, when the desired `get` object cannot be found', function(){
-    var result = getOrElse({ get: [testObj,'a.b.c.d'], else:{} });
+    var result = getOrElse([testObj, 'a.b.c.d'], {});
     expect(result).toEqual({});
   });
 
   it('should return the desired object, if it exists', function(){
-    var result = getOrElse({ get: [testObj,'b.y.z'], else:0 });
+    var result = getOrElse([testObj, 'b.y.z'], 0);
     expect(result).toEqual(56);
   });
 
   it('should consider a `null` property to not be desirable, so will return `else` value', function(){
-    var result = getOrElse({ get: [testObj,'b.p'], else:'' });
+    var result = getOrElse([testObj, 'b.p'], '');
     expect(result).toEqual('');
   });
 
   it('should return a whole object if that is what is what is desired and it exists', function(){
-    var result = getOrElse({ get: [testObj,'b'], else:{ f:''} });
-    expect(result).toEqual({p:null,x:3,y:{z:56}});
+    var result = getOrElse([testObj, 'b'], { f: ''});
+    expect(result).toEqual({p: null, x: 3, y: {z:56} });
   });
 
   it('should return `else` value if contextObj is undefined', function(){
     var n = undefined;
-    var result = getOrElse({ get: [n,'b'], else:'nopes' });
+    var result = getOrElse([n,'b'], 'nopes');
     expect(result).toEqual('nopes');
   });
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "get-or-else",
-  "version": "1.1.7",
+  "version": "2.0.0",
   "description": "Get Or Else in Javascript",
   "main": "index.js",
   "scripts": {
     "test:lint": "eslint index.js",
-    "test:unit": "mocha test.js",
+    "test:unit": "mocha index__test__.js",
     "test": "npm run test:lint && npm run test:unit"
   },
   "repository": {


### PR DESCRIPTION
Change argument signature to be less verbose.

e.g.
```
-    var result = getOrElse({ get: [testObj,'a.b.c.d'], else:{} });
+    var result = getOrElse([testObj, 'a.b.c.d'], {});
```